### PR TITLE
check offsetHeight or scrollHeight. offsetHeight returns zero when max-height is 0

### DIFF
--- a/resources/assets/js/animation/slideDown.js
+++ b/resources/assets/js/animation/slideDown.js
@@ -16,7 +16,7 @@ module.exports = (function() {
     el.style.transition = 'initial';
     el.style.visibility = 'hidden';
     el.style.maxHeight = 'initial';
-    var height = el.offsetHeight + 'px';
+    var height = (el.offsetHeight || el.scrollHeight) + 'px';
     el.style.removeProperty('visibility');
     el.style.maxHeight = '0';
     el.style.overflow = 'hidden';


### PR DESCRIPTION
Realized that the form success states weren't displaying correctly in IE11. This was due to el.offsetHeight return 0 when the message elements were hidden with max-height: 0. Adding a check for scrollHeight seems to be a safe backup.