### PR TITLE
Chrome Version Helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com) and this pr
 
 ## [Unreleased]
 
+### Added
+
+- Add `chrome.getVersion()` helper
+
 ## [2.6.3] - 2017-08-10
 
 ### Added

--- a/resources/assets/js/browserDetect/chrome.js
+++ b/resources/assets/js/browserDetect/chrome.js
@@ -1,0 +1,18 @@
+module.exports = (function(window, document) {
+
+  /**
+   * Returns the version of Chrome or a -1 (indicating the use of another browser).
+   * @see https://stackoverflow.com/a/4900484/1786459
+   * @return {Number}
+   */
+  function getVersion() {
+    let version = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+
+    return version ? parseInt(version[2], 10) : -1;
+  }
+
+  return {
+    version: getVersion
+  };
+
+})(window, document);

--- a/resources/assets/js/browserDetect/fontFeatures.js
+++ b/resources/assets/js/browserDetect/fontFeatures.js
@@ -1,6 +1,5 @@
-var internetExplorer = require('./internetExplorer');
+const internetExplorer = require('./internetExplorer');
 
-// TODO: Move to mode-front-end
 module.exports = (function(window, document) {
 
   /**
@@ -33,11 +32,11 @@ module.exports = (function(window, document) {
       return false;
     }
 
-    var activeClass = 'supports-font-features';
+    let activeClass = 'supports-font-features';
 
     // Check CSS.supports for `font-feature-settings`
     // Make an exception for IE+ since they don't support `supports` (HA!)
-    var supportsFontFeatures =
+    let supportsFontFeatures =
       supports("(font-feature-settings: 'smcp')") ||
       (internetExplorer.version() >= 10.0);
 

--- a/resources/assets/js/browserDetect/index.js
+++ b/resources/assets/js/browserDetect/index.js
@@ -1,5 +1,6 @@
 module.exports = (function() {
   return {
+    chrome: require('./chrome'),
     fontFeatures: require('./fontFeatures'),
     internetExplorer: require('./internetExplorer'),
     ios: require('./ios')

--- a/resources/assets/js/browserDetect/internetExplorer.js
+++ b/resources/assets/js/browserDetect/internetExplorer.js
@@ -1,4 +1,3 @@
-// TODO: Move to mode-front-end
 module.exports = (function(window, document) {
 
   /**
@@ -8,7 +7,7 @@ module.exports = (function(window, document) {
    * @return {Number}
    */
   function getVersion() {
-    var ieVersion = -1,
+    let ieVersion = -1,
       ieRegex;
 
     if (navigator.appName === 'Microsoft Internet Explorer') {
@@ -29,7 +28,7 @@ module.exports = (function(window, document) {
    * @return {Boolean}
    */
   function isLessThanIE11() {
-    var version = getVersion();
+    let version = getVersion();
 
     return version >= 0 && version < 11.0;
   }
@@ -47,7 +46,7 @@ module.exports = (function(window, document) {
    * @return {Boolean}
    */
   function updateDocumentClasses() {
-    var version = getVersion();
+    let version = getVersion();
 
     // Return false for non-IE browsers
     if (version < 0) {


### PR DESCRIPTION
Adding a helper to get the current Chrome version. Useful for working around `position:sticky` bugs (e.g., in versions 56–59).

## References

- [Position sticky has incorrect offsets when other elements have certain CSS property values](https://bugs.chromium.org/p/chromium/issues/detail?id=695729)
- [Can I use `position:sticky`](http://caniuse.com/#search=position%3Asticky)
