### PR TITLE
Drop let and const for builds that don't support ES6 😩

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,5 +1,5 @@
 // TODO: Use starter kit JS to avoid dupe code
 // require('../../../starter-kit/assets/js/app');
 
-const video = require('./video');
+var video = require('./video');
 video.player.init();

--- a/resources/assets/js/browserDetect/chrome.js
+++ b/resources/assets/js/browserDetect/chrome.js
@@ -6,7 +6,7 @@ module.exports = (function(window, document) {
    * @return {Number}
    */
   function getVersion() {
-    let version = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+    var version = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
 
     return version ? parseInt(version[2], 10) : -1;
   }

--- a/resources/assets/js/browserDetect/fontFeatures.js
+++ b/resources/assets/js/browserDetect/fontFeatures.js
@@ -1,4 +1,4 @@
-const internetExplorer = require('./internetExplorer');
+var internetExplorer = require('./internetExplorer');
 
 module.exports = (function(window, document) {
 
@@ -32,11 +32,11 @@ module.exports = (function(window, document) {
       return false;
     }
 
-    let activeClass = 'supports-font-features';
+    var activeClass = 'supports-font-features';
 
     // Check CSS.supports for `font-feature-settings`
     // Make an exception for IE+ since they don't support `supports` (HA!)
-    let supportsFontFeatures =
+    var supportsFontFeatures =
       supports("(font-feature-settings: 'smcp')") ||
       (internetExplorer.version() >= 10.0);
 

--- a/resources/assets/js/browserDetect/internetExplorer.js
+++ b/resources/assets/js/browserDetect/internetExplorer.js
@@ -7,7 +7,7 @@ module.exports = (function(window, document) {
    * @return {Number}
    */
   function getVersion() {
-    let ieVersion = -1,
+    var ieVersion = -1,
       ieRegex;
 
     if (navigator.appName === 'Microsoft Internet Explorer') {
@@ -28,7 +28,7 @@ module.exports = (function(window, document) {
    * @return {Boolean}
    */
   function isLessThanIE11() {
-    let version = getVersion();
+    var version = getVersion();
 
     return version >= 0 && version < 11.0;
   }
@@ -46,7 +46,7 @@ module.exports = (function(window, document) {
    * @return {Boolean}
    */
   function updateDocumentClasses() {
-    let version = getVersion();
+    var version = getVersion();
 
     // Return false for non-IE browsers
     if (version < 0) {

--- a/resources/assets/js/event/on.js
+++ b/resources/assets/js/event/on.js
@@ -10,19 +10,19 @@ module.exports = (function(window, document, undefined) {
    * @return {Boolean}
    */
   function on(parentSelector, eventName, childSelector, fn) {
-    let parent = document.querySelector(parentSelector);
+    var parent = document.querySelector(parentSelector);
 
     if (!parent) {
       return false;
     }
 
     parent.addEventListener(eventName, function(event) {
-      let possibleTargets = parent.querySelectorAll(childSelector);
-      let target = event.target;
+      var possibleTargets = parent.querySelectorAll(childSelector);
+      var target = event.target;
 
-      for (let i = 0, l = possibleTargets.length; i < l; i++) {
-        let el = target;
-        let p = possibleTargets[i];
+      for (var i = 0, l = possibleTargets.length; i < l; i++) {
+        var el = target;
+        var p = possibleTargets[i];
 
         while (el && el !== parent) {
           if (el === p) {

--- a/resources/assets/js/index.js
+++ b/resources/assets/js/index.js
@@ -7,7 +7,7 @@ category: JavaScript
 Use namespacing to require helper functions in your application:
 
 ```js
-const dom = require('mode-front-end/resources/assets/js/dom');
+var dom = require('mode-front-end/resources/assets/js/dom');
 ```
 
 ## Analytics

--- a/resources/assets/js/time/daysSince.js
+++ b/resources/assets/js/time/daysSince.js
@@ -12,12 +12,12 @@ module.exports = (function(window, document, undefined) {
       timestamp = parseInt(timestamp, 10);
     }
 
-    let then = new Date(timestamp);
+    var then = new Date(timestamp);
     then.setHours(0);
     then.setMinutes(0);
     then.setSeconds(0, 0);
 
-    let now = new Date();
+    var now = new Date();
     now.setHours(0);
     now.setMinutes(0);
     now.setSeconds(0, 0);
@@ -27,12 +27,12 @@ module.exports = (function(window, document, undefined) {
   }
 
   // Example:
-  // let today = new Date();
-  // let yesterday = new Date();
+  // var today = new Date();
+  // var yesterday = new Date();
   // yesterday.setDate(yesterday.getDate() - 1);
-  // let lastWeek = new Date();
+  // var lastWeek = new Date();
   // lastWeek.setDate(lastWeek.getDate() - 7);
-  // let tomorrow = new Date();
+  // var tomorrow = new Date();
   // tomorrow.setDate(tomorrow.getDate() + 1);
   // console.log(daysSince(today));
   // console.log(daysSince(yesterday));

--- a/resources/assets/js/video/player.js
+++ b/resources/assets/js/video/player.js
@@ -1,18 +1,18 @@
-const dom = require('../dom');
-const map = require('../array/map');
-const extend = require('../object/extend');
-const getYouTubeId = require('./getYouTubeId');
-const youTubeReady = require('./youTubeReady');
-// const analytics = require('../analytics');
+var dom = require('../dom');
+var map = require('../array/map');
+var extend = require('../object/extend');
+var getYouTubeId = require('./getYouTubeId');
+var youTubeReady = require('./youTubeReady');
+// var analytics = require('../analytics');
 
 // TODO: Create a reusable Video class from this
 module.exports = (function(window, document, undefined) {
 
-  const readyClass = 'is-ready';
-  const activeClass = 'is-active';
+  var readyClass = 'is-ready';
+  var activeClass = 'is-active';
 
   // Quality Pt. 1
-  const VIDEO_QUALITY_OPTIONS = {
+  var VIDEO_QUALITY_OPTIONS = {
     quality: 'hd720',
     breakpoint: 768
   };
@@ -48,9 +48,9 @@ module.exports = (function(window, document, undefined) {
    * @return {VideoPlayer}
    */
   function initVideoPlayer(videoElement) {
-    let YT = window.YT;
-    let videoOptions, videoId, playerOptions, videoPlayer;
-    let videoContainer = dom.closest(videoElement, '.js-video-wrapper');
+    var YT = window.YT;
+    var videoOptions, videoId, playerOptions, videoPlayer;
+    var videoContainer = dom.closest(videoElement, '.js-video-wrapper');
 
     // Wait for YouTube
     if (typeof YT === 'undefined') {
@@ -109,7 +109,7 @@ module.exports = (function(window, document, undefined) {
       setQuality(event.target, VIDEO_QUALITY_OPTIONS);
 
       // Allow custom play buttons
-      let playButtons = document.querySelectorAll('.js-video-open[data-video="#' + videoElement.id + '"]');
+      var playButtons = document.querySelectorAll('.js-video-open[data-video="#' + videoElement.id + '"]');
       map(playButtons, (button) => button.addEventListener('click', (e) => {
         if (videoPlayer) { videoPlayer.playVideo(); }
       }));

--- a/starter-kit/assets/js/app.js
+++ b/starter-kit/assets/js/app.js
@@ -18,5 +18,5 @@ require('mode-front-end/resources/assets/js/browserDetect/ios');
 require('mode-front-end/resources/assets/js/browserDetect/fontFeatures');
 
 // Video
-const video = require('mode-front-end/resources/assets/js/video');
+var video = require('mode-front-end/resources/assets/js/video');
 video.player.init();


### PR DESCRIPTION
Having a lot of issues with production builds that don't support `let` and `const`.

Reverting to `var` as a quick fix.