### PR TITLE
Directional Grid Gutters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [Unreleased]
+
+### Changed
+
+- Make `o-grid--gutters` use directional aliases (`horizontal`, `vertical`, and blank for both)
+
 ## [2.11.0] - 2017-10-31
 
 ### Changed

--- a/resources/assets/sass/objects/grid/_grid--gutters.scss
+++ b/resources/assets/sass/objects/grid/_grid--gutters.scss
@@ -50,13 +50,46 @@ category: Objects
     $class-name: '#{$class-name}-#{$alias}';
   }
 
-  @include breakpoints($class-name, $at-breakpoint) {
-    margin-right: 0;
-    margin-left: -$size;
+  $directions: ('vertical', 'horizontal');
+  $direction: null;
+  $temp-direction: $alias;
 
-    > .o-grid__item {
-      padding-right: 0;
-      padding-left: $size;
+  // Check whether $alias starts with a direction
+  $index: str-index($alias, '-');
+  @if ($index) {
+    $temp-direction: str-slice($alias, 1, $index - 1);
+  }
+
+  @each $x-direction in $directions {
+    @if not $direction and $temp-direction == $x-direction {
+      $direction: $x-direction;
+    }
+  }
+
+  // Set properties based on direction
+  @include breakpoints($class-name, $at-breakpoint) {
+    @if ($direction == 'vertical') {
+      margin-bottom: 0;
+      margin-top: -$size;
+
+      > .o-grid__item {
+        padding-bottom: 0;
+        padding-top: $size;
+      }
+    } @else if ($direction == 'horizontal') {
+      margin-right: 0;
+      margin-left: -$size;
+
+      > .o-grid__item {
+        padding-right: 0;
+        padding-left: $size;
+      }
+    } @else {
+      margin: -$size 0 0 -$size;
+
+      > .o-grid__item {
+        padding: -$size 0 0 -$size;
+      }
     }
   }
 }


### PR DESCRIPTION
Finding times where I want to set vertical grid gutters, or apply the same gutter to both sides.

This updates the `o-grid--gutters()` mixin to check for directional prefixes.

For example:

```scss
@include o-grid--gutters('sm'); // Both vertical and horizontal
@include o-grid--gutters('vertical-sm');
@include o-grid--gutters('horizontal-sm');
```